### PR TITLE
M8 module

### DIFF
--- a/ModularParts/M6_PrometheeDiscordance.py
+++ b/ModularParts/M6_PrometheeDiscordance.py
@@ -1,4 +1,5 @@
 import copy
+from core.preference_commons import overall_preference
 
 
 class PrometheeDiscordance:
@@ -17,6 +18,7 @@ class PrometheeDiscordance:
     def __calculate_partial_discordance(self, partial_preferences, other_partial_preferences=None):
         """
         Calculates partial discordance indices based on partial preference indices
+
         :param partial_preferences: partial preference of every alternative over other alternatives
         or profiles
         :return: 3D matrix of partial discordance indices
@@ -34,6 +36,7 @@ class PrometheeDiscordance:
     def __overall_discordance(self, partial_discordance, tau):
         """
         Calculates overall discordance by aggregating partial discordance indices.
+
         :param partial_discordance: matrix of partial discordance indices
         :param tau: technical parameter, τ ∈ [1, k], smaller τ → weaker discordance
         :return: matrix of overall discordance
@@ -51,11 +54,12 @@ class PrometheeDiscordance:
 
         return discordance
 
-    def calculate_discordance(self, tau, calculate_preference=False):
+    def compute_discordance(self, tau, preferences=None):
         """
         Calculates overall discordance by aggregating partial discordance indices.
+
         :param tau: technical parameter, τ ∈ [1, k], smaller τ → weaker discordance
-        :param calculate_preference: if True function returns already calculated preference instead of just discordance
+        :param preferences: if not empty function returns already calculated preference instead of just discordance
         :return: matrix of overall discordance and matrix of partial discordance indices. Alternatively: preference
         """
         if tau < 1 or tau > self.k:
@@ -72,7 +76,7 @@ class PrometheeDiscordance:
             for i in partial_discordance:
                 discordance.append(self.__overall_discordance(i, tau))
 
-        if calculate_preference:
-            return 0  # TODO: obliczanie preferencji z M8
+        if preferences is not None:
+            return overall_preference(preferences, discordance, self.categories_profiles)
         else:
             return discordance, partial_discordance

--- a/ModularParts/M7_PrometheeVeto.py
+++ b/ModularParts/M7_PrometheeVeto.py
@@ -56,10 +56,11 @@ class PrometheeVeto:
             ppIndices.append(criterionIndices)
         return ppIndices
 
-    def __partialVeto(self) -> List[List[List[NumericValue]]]:
+    def __partial_veto(self) -> List[List[List[NumericValue]]]:
         """
         Calculates partial veto of every alternative over other alternatives
         or profiles at every criterion based on deviations using a method chosen by user.
+
         :return: partial veto
         """
         deviations = pc.deviations(self.criteria, self.alternatives_performances, self.profile_performance_table)
@@ -72,25 +73,30 @@ class PrometheeVeto:
                 self.__veto_deep(deviations[1], self.profile_performance_table, self.alternatives_performances)]
         return ppIndices
 
-    def computeVetoIndices(self):
+    def compute_veto(self, preferences=None):
         """
         Calculates veto of every alternative over other alternatives
         or profiles based on partial veto
 
+        :param preferences: if not None function returns already calculated preference instead of just veto
         :return: veto
         :return: partial veto
         """
-        partialVet = self.__partialVeto()
+        partialVet = self.__partial_veto()
 
         if not self.categories_profiles:
-            return self.__Vetoes(partialVet, self.alternatives_performances), partialVet
+            veto = self.__vetoes(partialVet, self.alternatives_performances)
+            partial_veto = partialVet
         else:
-            partialVetcopied = partialVet[1], partialVet[0]
-            return (self.__Vetoes(partialVet[1], self.profile_performance_table, self.alternatives_performances),
-                    self.__Vetoes(partialVet[0], self.alternatives_performances, self.profile_performance_table)
-                    ), partialVetcopied
+            partial_veto = partialVet[1], partialVet[0]
+            veto = (self.__vetoes(partialVet[1], self.profile_performance_table, self.alternatives_performances),
+                    self.__vetoes(partialVet[0], self.alternatives_performances, self.profile_performance_table))
+        if preferences is not None:
+            return pc.overall_preference(preferences, veto)
+        else:
+            return veto, partial_veto
 
-    def __Vetoes(self, partialVet, i_iter, j_iter=None):
+    def __vetoes(self, partialVet, i_iter, j_iter=None):
         if j_iter is None:
             j_iter = i_iter
         Vetoes = []

--- a/ModularParts/M7_PrometheeVeto.py
+++ b/ModularParts/M7_PrometheeVeto.py
@@ -92,7 +92,7 @@ class PrometheeVeto:
             veto = (self.__vetoes(partialVet[1], self.profile_performance_table, self.alternatives_performances),
                     self.__vetoes(partialVet[0], self.alternatives_performances, self.profile_performance_table))
         if preferences is not None:
-            return pc.overall_preference(preferences, veto)
+            return pc.overall_preference(preferences, veto, self.categories_profiles)
         else:
             return veto, partial_veto
 

--- a/Tests/testy_M6.py
+++ b/Tests/testy_M6.py
@@ -1,9 +1,6 @@
 from ModularParts.M3_PrometheePreference import (PrometheePreference, PreferenceFunction)
 from ModularParts.M1_SurrogateWeights import SurrogateWeights
-from ModularParts.M9_PrometheeOutrankingFlows import PrometheeOutrankingFlows
-from ModularParts.M11_PrometheeIRanking import PrometheeIRanking
-from ModularParts.M13_PrometheeIIIFlow import PrometheeIIIFlow
-
+from ModularParts.M6_PrometheeDiscordance import PrometheeDiscordance
 
 kryteria = ['G1', 'G2']
 rankingKryteriow = ['G2', 'G1']
@@ -23,26 +20,24 @@ ap = [[10, 12],  # a1
       [11, 13],  # a2
       [12, 14]]  # a3
 
-# TEST M3 SAME WARIANTY
-print("--------Test modułu M3 dla samych wariantów----------")
+# TEST M6 SAME WARIANTY
+print("--------Test modułu M6 dla samych wariantów----------")
 
 aggregatedPI, partialPref = PrometheePreference(warianty, kryteria, ap, weights,
                                                 p_param, q_param, s_param, generalized_criteria,
                                                 directions).computePreferenceIndices()
-print("partial preferences", partialPref)
+print("partial preferences: ", partialPref)
 print("preferences : ", aggregatedPI)
 
-positiveFlow, negativeFlow = PrometheeOutrankingFlows(warianty, aggregatedPI).calculate_flows()
-print("positive flow: ", positiveFlow, "negative flow: ", negativeFlow)
+discordance, partial_discordance = PrometheeDiscordance(2, partialPref).compute_discordance(1.5)
+print("partial discordance: ", partial_discordance)
+print("discordance: ", discordance)
 
-pairs = PrometheeIRanking(warianty, positiveFlow, negativeFlow).calculate_ranking()
-print("Ranking M11_PrometheeIRanking:", pairs)
-intervals, pairs = PrometheeIIIFlow(warianty, positiveFlow, negativeFlow, aggregatedPI).calculate_ranking(0.2)
-print("Intervals:", intervals)
-print("Ranking M13_PrometheeIIIFlow:", pairs)
+overall_preference = PrometheeDiscordance(2, partialPref).compute_discordance(1.5, aggregatedPI)
+print("overall preferences: ", overall_preference)
 
-# TEST M3 PROFILE
-print("--------Test modułu M3 dla wariantów i profili----------")
+# TEST M6 PROFILE
+print("--------Test modułu M6 dla wariantów i profili----------")
 
 profile = ['b1', 'b2']
 #      G1  G2
@@ -55,5 +50,9 @@ aggregatedPI, partialPref = PrometheePreference(warianty, kryteria, ap, weights,
 print("partial preferences", partialPref)
 print("preferences: ", aggregatedPI)
 
-positiveFlow, negativeFlow = PrometheeOutrankingFlows(warianty, aggregatedPI).calculate_flows()
-print(positiveFlow, negativeFlow)
+discordance, partial_discordance = PrometheeDiscordance(2, partialPref, True).compute_discordance(1.25)
+print("partial discordance: ", partial_discordance)
+print("discordance: ", discordance)
+
+overall_preference = PrometheeDiscordance(2, partialPref, True).compute_discordance(1.5, aggregatedPI)
+print("overall preferences: ", overall_preference)

--- a/Tests/testy_M7.py
+++ b/Tests/testy_M7.py
@@ -1,8 +1,4 @@
-from ModularParts.M3_PrometheePreference import (PrometheePreference, PreferenceFunction)
 from ModularParts.M1_SurrogateWeights import SurrogateWeights
-from ModularParts.M9_PrometheeOutrankingFlows import PrometheeOutrankingFlows
-from ModularParts.M11_PrometheeIRanking import PrometheeIRanking
-from ModularParts.M13_PrometheeIIIFlow import PrometheeIIIFlow
 from ModularParts.M7_PrometheeVeto import PrometheeVeto
 
 kryteria = ['G1', 'G2']
@@ -23,7 +19,7 @@ ap = [[10, 12],  # a1
 print("--------Test modułu M7 dla samych wariantów----------")
 
 veto, partialVeto = PrometheeVeto(kryteria, ap, weights,
-                                  v_param, directions).computeVetoIndices()
+                                  v_param, directions).compute_veto()
 print("partial veto", partialVeto)
 print("Veto : ", veto)
 
@@ -36,7 +32,7 @@ pp = [[9.5, 11],  # b1
       [14, 13]]  # b2
 
 
-veto, partialVeto = PrometheeVeto( kryteria, ap, weights,
-                                  v_param, directions, categories_profiles=True, profile_performance_table=pp, full_veto=False).computeVetoIndices()
+veto, partialVeto = PrometheeVeto(kryteria, ap, weights,
+                                  v_param, directions, categories_profiles=True, profile_performance_table=pp, full_veto=False).compute_veto()
 print("partial veto", partialVeto)
 print("Veto : ", veto)

--- a/Tests/testy_M7.py
+++ b/Tests/testy_M7.py
@@ -1,8 +1,10 @@
 from ModularParts.M1_SurrogateWeights import SurrogateWeights
 from ModularParts.M7_PrometheeVeto import PrometheeVeto
+from ModularParts.M3_PrometheePreference import PrometheePreference, PreferenceFunction
 
 kryteria = ['G1', 'G2']
 rankingKryteriow = ['G2', 'G1']
+generalized_criteria = [PreferenceFunction.U_SHAPE, PreferenceFunction.V_SHAPE]
 directions = [0, 1]
 p_param = [4, 0.5]
 q_param = [0.4, 5]
@@ -18,10 +20,19 @@ ap = [[10, 12],  # a1
 # TEST M7 SAME WARIANTY
 print("--------Test modułu M7 dla samych wariantów----------")
 
+aggregatedPI, partialPref = PrometheePreference(warianty, kryteria, ap, weights,
+                                                p_param, q_param, s_param, generalized_criteria,
+                                                directions).computePreferenceIndices()
+print("preferences : ", aggregatedPI)
+
 veto, partialVeto = PrometheeVeto(kryteria, ap, weights,
                                   v_param, directions).compute_veto()
 print("partial veto", partialVeto)
 print("Veto : ", veto)
+
+overall_preference = PrometheeVeto(kryteria, ap, weights,
+                                   v_param, directions).compute_veto(aggregatedPI)
+print("overall preferences: ", overall_preference)
 
 # TEST M7 PROFILE
 print("--------Test modułu M7 dla profili ----------")
@@ -31,8 +42,18 @@ profile = ['b1', 'b2']
 pp = [[9.5, 11],  # b1
       [14, 13]]  # b2
 
+aggregatedPI, x = PrometheePreference(warianty, kryteria, ap, weights,
+                                      p_param, q_param, s_param, generalized_criteria,
+                                      directions, profile, pp).computePreferenceIndices()
+print("preferences : ", aggregatedPI)
 
 veto, partialVeto = PrometheeVeto(kryteria, ap, weights,
-                                  v_param, directions, categories_profiles=True, profile_performance_table=pp, full_veto=False).compute_veto()
+                                  v_param, directions, categories_profiles=True, profile_performance_table=pp,
+                                  full_veto=False).compute_veto()
 print("partial veto", partialVeto)
 print("Veto : ", veto)
+
+overall_preference = PrometheeVeto(kryteria, ap, weights,
+                                   v_param, directions, categories_profiles=True, profile_performance_table=pp,
+                                   full_veto=False).compute_veto(aggregatedPI)
+print("overall preferences: ", overall_preference)

--- a/core/preference_commons.py
+++ b/core/preference_commons.py
@@ -1,6 +1,8 @@
 import copy
 from typing import List
 
+import numpy as np
+
 from core.aliases import NumericValue
 
 
@@ -56,3 +58,28 @@ def deviations(criteria, alternatives_performances, profile_performance_table=No
         deviations_list.append(deviations_part)
 
     return deviations_list
+
+
+def overall_preference(preferences, discordances, profiles):
+    """
+    Combines preference and discordance/veto indices to compute overall preference
+
+    :param preferences: aggregated preference indices
+    :param discordances: aggregated discordance/veto indices
+    :param profiles: were the preferences and discordance/veto calculated with profiles
+    :returns: overall preference indices
+    """
+    if profiles:
+        for n in range(len(discordances)):
+            for i in range(len(discordances[n])):
+                for j in range(len(discordances[n][i])):
+                    discordances[n][i][j] = 1 - discordances[n][i][j]
+        overall_preferences = (np.multiply(preferences[0], discordances[0]).tolist(),
+                               np.multiply(preferences[1], discordances[1]).tolist())
+    else:
+        for n in range(len(discordances)):
+            for i in range(len(discordances[n])):
+                discordances[n][i] = 1 - discordances[n][i]
+        overall_preferences = np.multiply(preferences, discordances).tolist()
+
+    return overall_preferences


### PR DESCRIPTION
Moduł M8 został zaimplementowany jako funkcja w core, która jest używana przez moduły M6 i M7 jeżeli użytkownik chce otrzymać preferencje obliczone z vetem lub discordance obliczonym w tych modułach